### PR TITLE
introducing translation method with argos-translate as a free option(…

### DIFF
--- a/ValueSets.json
+++ b/ValueSets.json
@@ -4,7 +4,11 @@
     "source_lang" : "de"
   },
   {
-    "url": "http://fhir.de/ValueSet/bfarm/ops",
-    "source_lang": "de"
+    "url": "value-sets/kontaktart-de.json",
+    "source_lang" : "de"
+  },
+  {
+    "url": "value-sets/administrative-gender.json",
+    "source_lang" : "en"
   }
 ]

--- a/translate.py
+++ b/translate.py
@@ -16,12 +16,18 @@ def configure_args_parser():
     arg_parser.add_argument("--private_key", type=str, help="The private key")
     arg_parser.add_argument("--deepl_api_key", type=str, help="The DeepL API key")
     arg_parser.add_argument("--value_sets", type=str, help="File with the urls and languages")
-    arg_parser.add_argument("--target_folder",type=str,help="Folder to output the translated files to",nargs="?",default="code-systems")
-    arg_parser.add_argument("--log_level",type=str,help="notset|debug|info|warning|error|critical",nargs="?",default="info")
-    arg_parser.add_argument("--batch_size",type=int,help="Integer specifying the count of elements sent simultaneously",nargs="?",default="3")
-    arg_parser.add_argument('--dry_run', action='store_true', help='Do not translate, only count number of characters that would be translated')
+    arg_parser.add_argument("--target_folder", type=str, help="Folder to output the translated files to", nargs="?",
+                            default="code-systems")
+    arg_parser.add_argument("--log_level", type=str, help="notset|debug|info|warning|error|critical", nargs="?",
+                            default="info")
+    arg_parser.add_argument("--batch_size", type=int,
+                            help="Integer specifying the count of elements sent simultaneously", nargs="?", default="3")
+    arg_parser.add_argument('--dry_run', action='store_true',
+                            help='Do not translate, only count number of characters that would be translated')
+    arg_parser.add_argument('--translation_engine', type=str, help='deepl|argos')
 
     return arg_parser
+
 
 def configure_logging(log_level_arg):
     log_level = {
@@ -54,7 +60,11 @@ if __name__ == "__main__":
 
     for value_set in value_sets:
 
-        chars_translated = translator.translate(value_set["url"], value_set["source_lang"], args.dry_run, batch_size=args.batch_size)
+        chars_translated = translator.translate(value_set["url"],
+                                                value_set["source_lang"],
+                                                args.dry_run,
+                                                batch_size=args.batch_size,
+                                                translation_engine=args.translation_engine)
 
         if chars_translated > 0:
             logger.info(f"ValueSet: {value_set['url']} contains characters: {chars_translated}")
@@ -62,5 +72,5 @@ if __name__ == "__main__":
             translator.save(target_folder=args.target_folder)
             nr_of_translated_files += 1
 
-    logger.info("Total: %s files",nr_of_translated_files)
+    logger.info("Total: %s files", nr_of_translated_files)
     logger.info(f"Total: {characters_translated:,} characters translated")


### PR DESCRIPTION
…runs locally).

 THE ARGOS LIBRARY INSTALLS ONLY ON LINUX:
pip install argostranslate

https://github.com/argosopentech/argos-translate

 Example cmd:

python3 translate.py --terminology_server=https://public-test.mii-termserv.de/fhir/ --server_certificate=client_cert/fdpg.pem  --private_key=client_cert/fdpg_unencrypted.key --deepl_api_key=f935eb38-2912-49b6-9228-47d0f25600f4:fx --value_sets=ValueSets.json --target_folder=code-systems --log_level=info --batch_size=10 --translation_engine=argos